### PR TITLE
Use Timeout.timeout instead of Object#timeout

### DIFF
--- a/lib/god/system/slash_proc_poller.rb
+++ b/lib/god/system/slash_proc_poller.rb
@@ -61,7 +61,7 @@ module God
       # read from them. Try to use this sparingly as it is expensive.
       def self.readable?(path)
         begin
-          timeout(1) { File.read(path) }
+          Timeout.timeout(1) { File.read(path) }
         rescue Timeout::Error
           false
         end


### PR DESCRIPTION
This change suppresses the following warning:

```
warning: Object#timeout is deprecated, use Timeout.timeout instead.
```